### PR TITLE
Fix: lists: <ul> and <ol>

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -67,7 +67,7 @@ i{
 .scroll-to-link{
     cursor: pointer;
 }
-p{
+p, .content ul, .content ol{
     font-size: 14px;
     color: #777A7A;
     margin-bottom: 16px;
@@ -198,8 +198,6 @@ pre{
 .content h6, 
 .content p, 
 .content table, 
-.content ul, 
-.content ol, 
 .content aside, 
 .content dl {
     margin-right: 50%;
@@ -207,6 +205,10 @@ pre{
     box-sizing: border-box;
     display: block;
     max-width: 680px;
+}
+.content ul, 
+.content ol {
+    padding: 0 44px;
 }
 .content h2,
 .content h3, 


### PR DESCRIPTION
Fixed css for lists \<ul> and \<ol> in content segment

Before:
![image](https://user-images.githubusercontent.com/62695938/91601082-54193f00-e969-11ea-8e13-e1a4439c07af.png)

Now:
![image](https://user-images.githubusercontent.com/62695938/91601103-5da2a700-e969-11ea-80ae-09e94596561e.png)
